### PR TITLE
Changed InMemoryEventStore.Find overload type from System.Func<T, bool> to System.Linq.Expressions.Expression<System.Func<T, bool>>

### DIFF
--- a/src/MementoFX.Persistence.InMemory/InMemoryEventStore.cs
+++ b/src/MementoFX.Persistence.InMemory/InMemoryEventStore.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using MementoFX.Messaging;
 
 namespace MementoFX.Persistence.InMemory
@@ -25,9 +26,9 @@ namespace MementoFX.Persistence.InMemory
         /// <typeparam name="T">The type of the event</typeparam>
         /// <param name="filter">The requirement</param>
         /// <returns>The events which satisfy the given requirement</returns>
-        public override IEnumerable<T> Find<T>(Func<T, bool> filter)
+        public override IEnumerable<T> Find<T>(Expression<Func<T, bool>> filter)
         {
-            return Events.OfType<T>().Where(filter);
+            return Events.OfType<T>().Where(filter.Compile());
         }
 
         /// <summary>


### PR DESCRIPTION
As described on main project's [issue #6](https://github.com/MementoFX/MementoFX/issues/6) and related [pull request](https://github.com/MementoFX/MementoFX/pull/8), this PR changes the overload types to support `System.Linq.Expressions.Expression<System.Func<T, bool>>` as filter type on InMemoryEventStore implementation.